### PR TITLE
Provide manual benchmark workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+    inputs:
+      withBenchmark:
+        description: 'With Benchmark?'
+        default: false
 
 jobs:
   build:
@@ -44,3 +49,7 @@ jobs:
           npm run coverage
         env:
           CI: true
+
+      - name: Benchmark
+        if: github.event.inputs.withBenchmark
+        run: npm run benchmark


### PR DESCRIPTION
If I'm correct, this will be usable when it's in master branch
Then you can select to manual trigger the CI workflow in the upper right corner of the Actions tab

// https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/