### PR TITLE
package.json: Sync version with package-lock.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettierx": "^0.17.1",
-    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-promise": "^4.3.1",
     "expect": "^26.6.2",
     "mocha": "^8.3.0",
     "mocha-lcov-reporter": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lib"
   ],
   "devDependencies": {
-    "@types/node": "^14.14.25",
+    "@types/node": "^14.14.27",
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "@typescript-eslint/parser": "^4.15.0",
     "@wessberg/rollup-plugin-ts": "^1.3.8",
@@ -67,16 +67,16 @@
     "eslint-plugin-prettierx": "^0.17.1",
     "eslint-plugin-promise": "^4.2.1",
     "expect": "^26.6.2",
-    "mocha": "^8.2.1",
+    "mocha": "^8.3.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^15.1.0",
     "prettier": "^2.2.1",
     "prettier-plugin-organize-imports": "^1.1.1",
     "prettierx": "^0.17.0",
-    "rollup": "^2.38.5",
+    "rollup": "^2.39.0",
     "rollup-plugin-delete": "^2.0.0",
     "source-map-support": "^0.5.19",
-    "typescript": "^4.1.4",
+    "typescript": "^4.1.5",
     "worker-threads-pool": "^2.0.0",
     "workerpool": "^6.1.0"
   },


### PR DESCRIPTION
Dependabot seems to do a very bad job at keeping the two in sync

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com><!--
  Thanks for contributing to poolifier project.
  Please be sure to read our [contributing guidelines](https://github.com/pioardi/poolifier/blob/pr-template/CONTRIBUTING.md).
-->

## PR Checklist

- [x] Please add a description of your changes.
- [ ] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [ ] Please add a link to the open issue or task that this pull request will resolve.
- [ ] Add a note to the changelog to indicate the change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes please indicate it and migration info into the CHANGELOG.md file.

---

<!-- Your PR text -->
