### PR TITLE
Improve property namings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ _This is not a limitation by poolifier but NodeJS._
 #### Public properties renaming
 
 - Thread Pool's `numWorkers` is now `numberOfWorkers`
+- Thread Pool's `nextWorker` is now `nextWorkerIndex`
 
 #### Internal (protected) methods renaming
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,13 @@ _This is not a limitation by poolifier but NodeJS._
 - Thread Pool's `numWorkers` is now `numberOfWorkers`
 - Thread Pool's `nextWorker` is now `nextWorkerIndex`
 
-#### Internal (protected) methods renaming
+#### Internal (protected) properties and methods renaming
 
-Those methods are not intended to be used from final users
+These properties are not intended for end users
+
+- `id` => `nextMessageId`
+
+These methods are not intended for end users
 
 - `_chooseWorker` => `chooseWorker`
 - `_newWorker` => `newWorker`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ These properties are not intended for end users
 These methods are not intended for end users
 
 - `_chooseWorker` => `chooseWorker`
-- `_newWorker` => `newWorker`
+- `_newWorker` => `createWorker`
 - `_execute` => `internalExecute`
 - `_chooseWorker` => `chooseWorker`
 - `_checkAlive` => `checkAlive`

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -267,7 +267,7 @@ export abstract class AbstractPool<
   /**
    * Returns a newly created worker.
    */
-  protected abstract newWorker (): Worker
+  protected abstract createWorker (): Worker
 
   /**
    * Function that can be hooked up when a worker has been newly created and moved to the workers registry.
@@ -284,7 +284,7 @@ export abstract class AbstractPool<
    * @returns New, completely set up worker.
    */
   protected createAndSetupWorker (): Worker {
-    const worker: Worker = this.newWorker()
+    const worker: Worker = this.createWorker()
 
     worker.on('error', this.opts.errorHandler ?? (() => {}))
     worker.on('online', this.opts.onlineHandler ?? (() => {}))

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -285,14 +285,19 @@ export abstract class AbstractPool<
    */
   protected createAndSetupWorker (): Worker {
     const worker: Worker = this.newWorker()
+
     worker.on('error', this.opts.errorHandler ?? (() => {}))
     worker.on('online', this.opts.onlineHandler ?? (() => {}))
     // TODO handle properly when a worker exit
     worker.on('exit', this.opts.exitHandler ?? (() => {}))
+
     this.workers.push(worker)
-    this.afterNewWorkerPushed(worker)
-    // init tasks map
+
+    // Init tasks map
     this.tasks.set(worker, 0)
+
+    this.afterNewWorkerPushed(worker)
+
     return worker
   }
 }

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -123,7 +123,7 @@ export abstract class AbstractPool<
     this.setupHook()
 
     for (let i = 1; i <= this.numberOfWorkers; i++) {
-      this.internalNewWorker()
+      this.createAndSetupWorker()
     }
 
     this.emitter = new PoolEmitter()
@@ -283,7 +283,7 @@ export abstract class AbstractPool<
    *
    * @returns New, completely set up worker.
    */
-  protected internalNewWorker (): Worker {
+  protected createAndSetupWorker (): Worker {
     const worker: Worker = this.newWorker()
     worker.on('error', this.opts.errorHandler ?? (() => {}))
     worker.on('online', this.opts.onlineHandler ?? (() => {}))

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -141,6 +141,16 @@ export abstract class AbstractPool<
   }
 
   /**
+   * Index for the next worker.
+   *
+   * @returns Index for the next worker.
+   * @deprecated Only here for backward compatibility.
+   */
+  public get nextWorker (): number {
+    return this.nextWorkerIndex
+  }
+
+  /**
    * Setup hook that can be overridden by a Poolifier pool implementation
    * to run code before workers are created in the abstract constructor.
    */

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -276,7 +276,7 @@ export abstract class AbstractPool<
    *
    * @param worker The newly created worker.
    */
-  protected abstract afterNewWorkerPushed (worker: Worker): void
+  protected abstract afterWorkerSetup (worker: Worker): void
 
   /**
    * Creates a new worker for this pool and sets it up completely.
@@ -296,7 +296,7 @@ export abstract class AbstractPool<
     // Init tasks map
     this.tasks.set(worker, 0)
 
-    this.afterNewWorkerPushed(worker)
+    this.afterWorkerSetup(worker)
 
     return worker
   }

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -76,9 +76,9 @@ export abstract class AbstractPool<
   public readonly workers: Worker[] = []
 
   /**
-   * ID for the next worker.
+   * Index for the next worker.
    */
-  public nextWorker: number = 0
+  public nextWorkerIndex: number = 0
 
   /**
    * - `key`: The `Worker`
@@ -245,9 +245,10 @@ export abstract class AbstractPool<
    * @returns Worker.
    */
   protected chooseWorker (): Worker {
-    this.nextWorker =
-      this.nextWorker === this.workers.length - 1 ? 0 : this.nextWorker + 1
-    return this.workers[this.nextWorker]
+    const chosenWorker = this.workers[this.nextWorkerIndex]
+    this.nextWorkerIndex++
+    this.nextWorkerIndex %= this.workers.length
+    return chosenWorker
   }
 
   /**

--- a/src/pools/cluster/dynamic.ts
+++ b/src/pools/cluster/dynamic.ts
@@ -63,7 +63,7 @@ export class DynamicClusterPool<
         return super.chooseWorker()
       }
       // All workers are busy, create a new worker
-      const worker = this.internalNewWorker()
+      const worker = this.createAndSetupWorker()
       worker.on('message', (message: MessageValue<Data>) => {
         if (message.kill) {
           this.sendToWorker(worker, { kill: 1 })

--- a/src/pools/cluster/fixed.ts
+++ b/src/pools/cluster/fixed.ts
@@ -85,7 +85,7 @@ export class FixedClusterPool<
     return fork(this.opts.env)
   }
 
-  protected afterNewWorkerPushed (worker: Worker): void {
+  protected afterWorkerSetup (worker: Worker): void {
     // we will attach a listener for every task,
     // when task is completed the listener will be removed but to avoid warnings we are increasing the max listeners size
     worker.setMaxListeners(this.opts.maxTasks ?? 1000)

--- a/src/pools/cluster/fixed.ts
+++ b/src/pools/cluster/fixed.ts
@@ -81,7 +81,7 @@ export class FixedClusterPool<
     port.removeListener('message', listener)
   }
 
-  protected newWorker (): Worker {
+  protected createWorker (): Worker {
     return fork(this.opts.env)
   }
 

--- a/src/pools/pool.ts
+++ b/src/pools/pool.ts
@@ -6,14 +6,14 @@
  */
 export interface IPool<Data = unknown, Response = unknown> {
   /**
-   * Shut down every current worker in this pool.
-   */
-  destroy(): Promise<void>
-  /**
    * Perform the task specified in the constructor with the data parameter.
    *
    * @param data The input for the specified task.
    * @returns Promise that will be resolved when the task is successfully completed.
    */
   execute(data: Data): Promise<Response>
+  /**
+   * Shut down every current worker in this pool.
+   */
+  destroy(): Promise<void>
 }

--- a/src/pools/thread/dynamic.ts
+++ b/src/pools/thread/dynamic.ts
@@ -63,7 +63,7 @@ export class DynamicThreadPool<
         return super.chooseWorker()
       }
       // all workers are busy create a new worker
-      const worker = this.internalNewWorker()
+      const worker = this.createAndSetupWorker()
       worker.port2?.on('message', (message: MessageValue<Data>) => {
         if (message.kill) {
           this.sendToWorker(worker, { kill: 1 })

--- a/src/pools/thread/dynamic.ts
+++ b/src/pools/thread/dynamic.ts
@@ -55,14 +55,14 @@ export class DynamicThreadPool<
     }
 
     if (worker) {
-      // a worker is free, use it
+      // A worker is free, use it
       return worker
     } else {
       if (this.workers.length === this.max) {
         this.emitter.emit('FullPool')
         return super.chooseWorker()
       }
-      // all workers are busy create a new worker
+      // All workers are busy, create a new worker
       const worker = this.createAndSetupWorker()
       worker.port2?.on('message', (message: MessageValue<Data>) => {
         if (message.kill) {

--- a/src/pools/thread/fixed.ts
+++ b/src/pools/thread/fixed.ts
@@ -72,7 +72,7 @@ export class FixedThreadPool<
     port.port2?.removeListener('message', listener)
   }
 
-  protected newWorker (): ThreadWorkerWithMessageChannel {
+  protected createWorker (): ThreadWorkerWithMessageChannel {
     return new Worker(this.filePath, {
       env: SHARE_ENV
     })

--- a/src/pools/thread/fixed.ts
+++ b/src/pools/thread/fixed.ts
@@ -78,9 +78,7 @@ export class FixedThreadPool<
     })
   }
 
-  protected afterNewWorkerPushed (
-    worker: ThreadWorkerWithMessageChannel
-  ): void {
+  protected afterWorkerSetup (worker: ThreadWorkerWithMessageChannel): void {
     const { port1, port2 } = new MessageChannel()
     worker.postMessage({ parent: port1 }, [port1])
     worker.port1 = port1


### PR DESCRIPTION
<!--
  Thanks for contributing to poolifier project.
  Please be sure to read our [contributing guidelines](https://github.com/pioardi/poolifier/blob/pr-template/CONTRIBUTING.md).
-->

## PR Checklist

- [x] Please add a description of your changes.
- [ ] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] Please add a link to the open issue or task that this pull request will resolve.
- [x] Add a note to the changelog to indicate the change.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

If yes please indicate it and migration info into the CHANGELOG.md file.

---

<!-- Your PR text -->

closes #134 

Renamings

- `nextWorker` to `nextWorkerIndex`
- `id` to `nextMessageId`
- `internalNewWorker` to `createAndSetupWorker`
- `afterNewWorkerPushed` to `afterWorkerSetup`
- `newWorker` to `createWorker`

Add backward compatibility and added changelog entry

Fixed some comments

Organize `createAndSetupWorker` method
Reorder functions
