### PR TITLE
De-duplicate code for workers

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,3 +1,6 @@
+import type { Worker } from 'cluster'
+import type { MessagePort } from 'worker_threads'
+
 /**
  * Make all properties in T non-readonly
  */
@@ -24,7 +27,10 @@ export type JSONArray = Array<JSONValue>
 /**
  * Message object that is passed between worker and main worker.
  */
-export interface MessageValue<Data = unknown> {
+export interface MessageValue<
+  Data = unknown,
+  MainWorker extends Worker | MessagePort | unknown = unknown
+> {
   /**
    * Input data that will be passed to the worker.
    */
@@ -46,5 +52,5 @@ export interface MessageValue<Data = unknown> {
    *
    * _Only for internal use_
    */
-  readonly parent?: MessagePort
+  readonly parent?: MainWorker
 }

--- a/src/worker/abstract-worker.ts
+++ b/src/worker/abstract-worker.ts
@@ -55,7 +55,7 @@ export abstract class AbstractWorker<
     this.async = !!this.opts.async
     this.lastTask = Date.now()
     if (!fn) throw new Error('fn parameter is mandatory')
-    // keep the worker active
+    // Keep the worker active
     if (!isMain) {
       this.interval = setInterval(
         this.checkAlive.bind(this),
@@ -66,19 +66,18 @@ export abstract class AbstractWorker<
 
     this.mainWorker?.on('message', (value: MessageValue<Data, MainWorker>) => {
       if (value?.data && value.id) {
-        // here you will receive messages
-        // console.log('This is the main worker ' + isMaster)
+        // Here you will receive messages
         if (this.async) {
           this.runInAsyncScope(this.runAsync.bind(this), this, fn, value)
         } else {
           this.runInAsyncScope(this.run.bind(this), this, fn, value)
         }
       } else if (value.parent) {
-        // save the port to communicate with the main thread
-        // this will be received once
+        // Save a reference of the main worker to communicate with it
+        // This will be received once
         this.mainWorker = value.parent
       } else if (value.kill) {
-        // here is time to kill this worker, just clearing the interval
+        // Here is time to kill this worker, just clearing the interval
         if (this.interval) clearInterval(this.interval)
         this.emitDestroy()
       }

--- a/src/worker/cluster-worker.ts
+++ b/src/worker/cluster-worker.ts
@@ -30,27 +30,7 @@ export class ClusterWorker<
    * @param opts Options for the worker.
    */
   public constructor (fn: (data: Data) => Response, opts: WorkerOptions = {}) {
-    super('worker-cluster-pool:pioardi', isMaster, fn, opts)
-
-    worker.on('message', (value: MessageValue<Data>) => {
-      if (value?.data && value.id) {
-        // here you will receive messages
-        // console.log('This is the main worker ' + isMaster)
-        if (this.async) {
-          this.runInAsyncScope(this.runAsync.bind(this), this, fn, value)
-        } else {
-          this.runInAsyncScope(this.run.bind(this), this, fn, value)
-        }
-      } else if (value.kill) {
-        // here is time to kill this worker, just clearing the interval
-        if (this.interval) clearInterval(this.interval)
-        this.emitDestroy()
-      }
-    })
-  }
-
-  protected getMainWorker (): Worker {
-    return worker
+    super('worker-cluster-pool:pioardi', isMaster, fn, worker, opts)
   }
 
   protected sendToMainWorker (message: MessageValue<Response>): void {

--- a/src/worker/thread-worker.ts
+++ b/src/worker/thread-worker.ts
@@ -1,3 +1,4 @@
+import type { MessagePort } from 'worker_threads'
 import { isMainThread, parentPort } from 'worker_threads'
 import type { JSONValue, MessageValue } from '../utility-types'
 import { AbstractWorker } from './abstract-worker'
@@ -23,45 +24,13 @@ export class ThreadWorker<
   Response extends JSONValue = JSONValue
 > extends AbstractWorker<MessagePort, Data, Response> {
   /**
-   * Reference to main thread.
-   */
-  protected parent?: MessagePort
-
-  /**
    * Constructs a new poolifier thread worker.
    *
    * @param fn Function processed by the worker when the pool's `execution` function is invoked.
    * @param opts Options for the worker.
    */
   public constructor (fn: (data: Data) => Response, opts: WorkerOptions = {}) {
-    super('worker-thread-pool:pioardi', isMainThread, fn, opts)
-
-    parentPort?.on('message', (value: MessageValue<Data>) => {
-      if (value?.data && value.id) {
-        // here you will receive messages
-        // console.log('This is the main worker ' + isMainThread)
-        if (this.async) {
-          this.runInAsyncScope(this.runAsync.bind(this), this, fn, value)
-        } else {
-          this.runInAsyncScope(this.run.bind(this), this, fn, value)
-        }
-      } else if (value.parent) {
-        // save the port to communicate with the main thread
-        // this will be received once
-        this.parent = value.parent
-      } else if (value.kill) {
-        // here is time to kill this worker, just clearing the interval
-        if (this.interval) clearInterval(this.interval)
-        this.emitDestroy()
-      }
-    })
-  }
-
-  protected getMainWorker (): MessagePort {
-    if (!this.parent) {
-      throw new Error('Parent was not set')
-    }
-    return this.parent
+    super('worker-thread-pool:pioardi', isMainThread, fn, parentPort, opts)
   }
 
   protected sendToMainWorker (message: MessageValue<Response>): void {


### PR DESCRIPTION
<!--
  Thanks for contributing to poolifier project.
  Please be sure to read our [contributing guidelines](https://github.com/pioardi/poolifier/blob/pr-template/CONTRIBUTING.md).
-->

## PR Checklist

- [x] Please add a description of your changes.
- [ ] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] Please add a link to the open issue or task that this pull request will resolve.
- [ ] Add a note to the changelog to indicate the change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes please indicate it and migration info into the CHANGELOG.md file.

---

<!-- Your PR text -->

closes #121 

This PR moves duplicate code in worker constructors to the `AbstractWorker`
As a side effect, also some other methods was also moved directly into the `AbstractWorker`